### PR TITLE
Fix temporary pointers problems

### DIFF
--- a/src/http/test/http_test.cpp
+++ b/src/http/test/http_test.cpp
@@ -569,6 +569,7 @@ struct SignedRequestProcessor : public http::SimpleRequestProcessor
 
   // TODO: Fix
   virtual void handle_request(
+    int32_t stream_id,
     llhttp_method method,
     const std::string_view& url,
     http::HeaderMap&& headers,
@@ -583,7 +584,7 @@ struct SignedRequestProcessor : public http::SimpleRequestProcessor
     }
 
     http::SimpleRequestProcessor::handle_request(
-      method, url, std::move(headers), std::move(body));
+      stream_id, method, url, std::move(headers), std::move(body));
   }
 };
 

--- a/src/tls/server.h
+++ b/src/tls/server.h
@@ -45,7 +45,7 @@ namespace tls
 
       // Configure protocols negotiated by ALPN
       static unsigned char alpn_protos_data[] = {
-        8, 'h', 't', 't', 'p', '/', '1', '.', '1'};
+        2, 'h', '2', 8, 'h', 't', 't', 'p', '/', '1', '.', '1'};
       static AlpnProtocols alpn_protos{
         alpn_protos_data, sizeof(alpn_protos_data)};
       SSL_CTX_set_alpn_select_cb(cfg, alpn_select_cb, &alpn_protos);


### PR DESCRIPTION
This is what I had to do to make it run. The main problem were the automatic conversions of `const char *` strings to `std::string`s, which immediately vanished after a call to `make_nv`.